### PR TITLE
Fixes

### DIFF
--- a/testsweeper.cc
+++ b/testsweeper.cc
@@ -306,7 +306,7 @@ int scan_range( const char** pstr, double* start, double* end, double* step )
 {
     int bytes1, bytes2, bytes3, cnt;
     cnt = sscanf( *pstr, "%lf %n: %lf %n: %lf %n",
-                  step, &bytes1, end, &bytes2, step, &bytes3 );
+                  start, &bytes1, end, &bytes2, step, &bytes3 );
     if (cnt == 3) {
         if (*start == *end)
             *step = 0;

--- a/testsweeper.cc
+++ b/testsweeper.cc
@@ -230,7 +230,7 @@ int64_t scan_multiplier( const char **pstr )
 ///
 int scan_range( const char** pstr, int64_t* start, int64_t* end, int64_t* step )
 {
-    long long start_, end_, step_;
+    long long start_ = 0, end_ = 0, step_ = 0;
     int bytes;
     const char* str = *pstr;
 


### PR DESCRIPTION
- clang complained about uninitialized values in some cases.
- fix `start` that was accidentally changed to `step` in e203b01