### PR TITLE
Add missing include for INT64_MAX

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -4,6 +4,7 @@
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
 #include <complex>
+#include <cstdint>
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Failed to compile for me with gcc 13.1 on Manjaro without the include.