### PR TITLE
in set_default, reset the value only if it is still the default

### DIFF
--- a/testsweeper.hh
+++ b/testsweeper.hh
@@ -331,8 +331,10 @@ public:
     void set_default( const T& default_value )
     {
         default_value_ = default_value;
-        values_.clear();
-        values_.push_back( default_value );
+        if (is_default_) {
+            values_.clear();
+            values_.push_back( default_value );
+        }
     }
 
     virtual void reset_output()


### PR DESCRIPTION
Ran into an issue in [SLATE PR 133](https://github.com/icl-utk-edu/slate/pull/133) that `set_default()` would override the user's parameter values. Turns out TestSweeper already had `is_default_`, we just weren't using it inside `set_default()`.