### PR TITLE
Add soversion to shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,12 @@ project(
     LANGUAGES CXX
 )
 
+# See notes in GNUmakefile about using abi-compliance-checker.
+# soversion is major ABI version.
+set( abi_version 1.0.0 )
+string( REPLACE "." ";" abi_list "${abi_version}" )
+list( GET abi_list 0 soversion )
+
 include( CheckCXXCompilerFlag )
 
 # When built as a sub-project, add a namespace to make targets unique,
@@ -32,6 +38,16 @@ endif()
 
 #-------------------------------------------------------------------------------
 # Options
+if (testsweeper_is_project)
+    set( log "" CACHE STRING "Shorthand for CMAKE_MESSAGE_LOG_LEVEL" )
+    set_property( CACHE log PROPERTY STRINGS
+                  FATAL_ERROR SEND_ERROR WARNING AUTHOR_WARNING DEPRECATION
+                  NOTICE STATUS VERBOSE DEBUG TRACE )
+    if (log)
+        set( CMAKE_MESSAGE_LOG_LEVEL "${log}" )
+    endif()
+endif()
+
 option( BUILD_SHARED_LIBS "Build shared libraries" true )
 option( build_tests "Build test suite" "${testsweeper_is_project}" )
 option( color "Use ANSI color output" true )
@@ -68,6 +84,8 @@ use_openmp             = ${use_openmp}
 testsweeper_install    = ${testsweeper_install}
 testsweeper_is_project = ${testsweeper_is_project}
 testsweeper_           = ${testsweeper_}
+abi_version            = ${abi_version}
+soversion              = ${soversion}
 " )
 
 #-------------------------------------------------------------------------------
@@ -130,6 +148,8 @@ set_target_properties(
     CXX_STANDARD_REQUIRED true  # prohibit < c++17
     CXX_EXTENSIONS false        # prohibit gnu++17
     WINDOWS_EXPORT_ALL_SYMBOLS ON
+    VERSION   "${abi_version}"
+    SOVERSION "${soversion}"
 )
 
 if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -73,10 +73,12 @@ ifneq ($(findstring darwin, $(ostype)),)
                      -current_version ${abi_version} \
                      -compatibility_version ${soversion}
     so = dylib
-    so2 = .dylib  # on macOS, .dylib comes after version: libfoo.4.dylib
+    so2 = .dylib
+    # on macOS, .dylib comes after version: libfoo.4.dylib
 else
     so = so
-    so1 = .so  # on Linux, .so comes before version: libfoo.so.4
+    so1 = .so
+    # on Linux, .so comes before version: libfoo.so.4
 endif
 
 #-------------------------------------------------------------------------------

--- a/GNUmakefile.subdir
+++ b/GNUmakefile.subdir
@@ -1,0 +1,50 @@
+# Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+#
+# Subdirectories include this makefile to forward rules to the top level makefile.
+# Define ${top} for where the top level is.
+# Example: src/GNUmakefile:
+#     top = ..
+#     include ${top}/GNUmakefile.subdir
+
+.SUFFIXES:
+
+pwd     := ${shell pwd}
+abs_top := ${abspath ${top}}
+cdir    := ${subst ${abs_top}/,,${pwd}}
+
+.DEFAULT_GOAL: ${cdir}
+.PHONY: ${cdir}
+
+${cdir}:
+	cd ${top} && ${MAKE} $@
+
+DONT_FORWARD += echo_sub
+echo_sub:
+	@echo "pwd     ${pwd}"
+	@echo "abs_top ${abs_top}"
+	@echo "cdir    ${cdir}"
+
+# ------------------------------------------------------------------------------
+ifneq (${MAKECMDGOALS},)
+
+# If arguments are given, presumably files like test.o, forward them to top
+# with cdir prefix.
+# All files are forwarded as one rule, based on first; rest are quietly ignored.
+goals   := ${filter-out echo ${DONT_FORWARD}, ${MAKECMDGOALS}}
+forward := ${addprefix ${cdir}/, ${goals}}
+first   := ${firstword ${goals}}
+rest    := ${wordlist 2, ${words ${goals}}, ${goals}}
+
+${first}: force
+	cd ${top} && ${MAKE} ${forward}
+
+${rest}: force
+	@echo > /dev/null
+
+endif
+# ------------------------------------------------------------------------------
+
+force: ;

--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -1,0 +1,2 @@
+top = ..
+include ${top}/GNUmakefile.subdir

--- a/testsweeper.hh
+++ b/testsweeper.hh
@@ -421,13 +421,6 @@ public:
         values_[ index_ ] = value;
     }
 
-    [[deprecated( "use param() instead of param.value(). To be removed 2024-03." )]]
-    T& value()
-    {
-        used_ = true;
-        return values_[ index_ ];
-    }
-
     void set_default( const T& default_value )
     {
         default_value_ = default_value;


### PR DESCRIPTION
TestSweeper (and related libraries, BLAS++, LAPACK++, SLATE) have used a date version scheme: `yyyy-mm-dd`. (At one point, `dd` was simply a counter starting from 0, but now it is the month day.) This has certain advantages, for instance making it clear when someone is using an out-dated version. However, it doesn't work well for versioning the ABI (application binary interface), which works better with semantic versioning, interpreted as applied to the ABI. The [semantic versioning spec](https://semver.org/) is for the API (application programming interface), which can change differently than the ABI. For instance:

* Reordering members of a struct changes the ABI but not the API. Client code needs recompiling but does not need modifications.
* Removing a function changes both the API and the ABI. Client code needs to be updated.
* Changing a templated function's prototype changes the API, but not necessarily the ABI if it is not instantiated in the library. Similarly, changing a macro changes the API but not the ABI.

The GNU libtool manual explicitly says, "Never try to set the interface numbers so that they correspond to the release number of your package."

Therefore, we are versioning the ABI separately from the API, using a form of semantic versioning. We will use the [abi-compliance-checker](https://github.com/lvc/abi-compliance-checker) to compare releases of the library. Rules:

* If a public struct is modified or removed, or arguments of a function change (e.g., int to int64), or a function is removed, bump the major version and reset the minor and micro version.
* If a new public structure or function is added, bump the minor version and reset the micro version.
* If changes are only bug fixes or internal structures and functions, bump the micro version.